### PR TITLE
Terraform: Fixes CloudFront SSL error on default cert creation

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -209,11 +209,21 @@ resource "aws_cloudfront_distribution" "portfolio_website" {
     Name = "Portfolio Website Distribution"
   }
 
-  viewer_certificate {
-    cloudfront_default_certificate = var.domain_name == "" ? true : false
-    acm_certificate_arn           = var.domain_name != "" ? aws_acm_certificate.portfolio_cert[0].arn : null
-    ssl_support_method            = var.domain_name != "" ? "sni-only" : null
-    minimum_protocol_version      = var.domain_name != "" ? "TLSv1.2_2021" : null
+  # Conditional viewer certificate configuration
+  dynamic "viewer_certificate" {
+    for_each = var.domain_name == "" ? [1] : []
+    content {
+      cloudfront_default_certificate = true
+    }
+  }
+
+  dynamic "viewer_certificate" {
+    for_each = var.domain_name != "" ? [1] : []
+    content {
+      acm_certificate_arn      = aws_acm_certificate.portfolio_cert[0].arn
+      ssl_support_method       = "sni-only"
+      minimum_protocol_version = "TLSv1.2_2021"
+    }
   }
 }
 


### PR DESCRIPTION
Fixing an issue in which we were defining our `viewer_certificate` to have fields with null values for the default cert, but custom values when using our custom domain. But CloudFront doesn't allow these fields to be defined for the default cert, even if their values are null. So we now define two different dynamic viewer certificates, one for  the default cert and one for our custom domain cert