### PR TITLE
S3 Bucket Name Region-Proof Uniqueness

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -105,7 +105,7 @@ After successful deployment, the following outputs will be available:
 
 - `website_url`: Complete website URL
 - `cloudfront_distribution_id`: CloudFront distribution ID
-- `website_bucket_name`: S3 bucket name
+- `website_bucket_name`: S3 bucket base name (region automatically appended)
 - `route53_name_servers`: DNS name servers (if using custom domain)
 
 ## 🔄 CI/CD Integration
@@ -120,7 +120,7 @@ The Terraform Cloud workspace integrates with GitHub Actions for:
 ### Common Issues
 
 1. **Bucket name already exists**:
-   - Change `website_bucket_name` to a unique value
+   - Change `website_bucket_name` base value if needed (region suffix ensures uniqueness)
    - S3 bucket names must be globally unique
 
 2. **AWS credentials error**:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -42,7 +42,7 @@ provider "aws" {
 
 # S3 Bucket for Static Website Hosting
 resource "aws_s3_bucket" "portfolio_website" {
-  bucket = var.website_bucket_name
+  bucket = "${var.website_bucket_name}-${var.aws_region}"
 }
 
 # S3 Bucket Public Access Block
@@ -123,7 +123,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "portfolio_website" {
 # S3 Bucket for CloudFront Logs (only if logging enabled)
 resource "aws_s3_bucket" "cloudfront_logs" {
   count  = var.enable_cloudfront_logging ? 1 : 0
-  bucket = "${var.website_bucket_name}-cloudfront-logs"
+  bucket = "${var.website_bucket_name}-${var.aws_region}-cloudfront-logs"
 }
 
 resource "aws_s3_bucket_ownership_controls" "cloudfront_logs" {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -7,7 +7,7 @@ aws_region = "us-west-2"
 environment = "prod"
 
 # Website Configuration
-website_bucket_name = "vansteve-portfolio-website"
+website_bucket_name = "vansteve-portfolio-website"  # Region will be auto-appended: vansteve-portfolio-website-us-west-2
 domain_name = ""  # Leave empty to use CloudFront domain, or set to your custom domain like "fitzs.io"
 
 # Project Configuration

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -24,12 +24,12 @@ variable "environment" {
 }
 
 variable "website_bucket_name" {
-  description = "Name of the S3 bucket for website hosting"
+  description = "Base name of the S3 bucket for website hosting (region will be appended automatically)"
   type        = string
   
   validation {
-    condition = can(regex("^[a-z0-9][a-z0-9.-]*[a-z0-9]$", var.website_bucket_name)) && length(var.website_bucket_name) >= 3 && length(var.website_bucket_name) <= 63
-    error_message = "S3 bucket name must be 3-63 characters, lowercase letters, numbers, and hyphens only."
+    condition = can(regex("^[a-z0-9][a-z0-9.-]*[a-z0-9]$", var.website_bucket_name)) && length(var.website_bucket_name) >= 3 && length(var.website_bucket_name) <= 45
+    error_message = "S3 bucket base name must be 3-45 characters, lowercase letters, numbers, and hyphens only (region suffix will be added)."
   }
 }
 


### PR DESCRIPTION
Feat: Updated s3 bucket name to guarantee region-proof uniqueness, to avoid an issue we're having in moving from us-east-1 to us-west-2 related to dns propagation