### PR TITLE
(Docs) Task 1.4: Setup Domain and DNS in Route 53

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ style K padding:10px
 - **AWS Account** with appropriate permissions
 - **Terraform Cloud Account** for state management
 - **GitHub Account** with repository access
-- **Domain Name** (optional, can use CloudFront distribution URL)
+- **Custom Domain Name** for production deployment (configured via IONOS at the time of writing)
 
 ### Local Development Setup
 
@@ -191,18 +191,16 @@ style K padding:10px
    - Create workspace in Terraform Cloud
    - Set up AWS credentials as environment variables
    - Configure backend in `terraform/environments/*/backend.tf`
+   - Set `domain_name` variable for production custom domain
 
 2. **Deploy infrastructure**
-   ```bash
-   cd terraform/environments/prod
-   terraform init
-   terraform plan
-   terraform apply
-   ```
+   - **Development**: CLI-driven workflow (`terraform apply`)
+   - **Staging/Production**: VCS-driven workflow (merge to `main` triggers auto-deployment)
 
 3. **Deploy website**
-   - Push to `main` branch triggers staging deployment
-   - Create release tag triggers production deployment
+   - **TBD**: Website build and deployment pipeline not yet implemented
+   - **Future**: Will include automated content deployment on code changes
+   - **Current**: Only infrastructure (S3, CloudFront, Route 53) is deployed
 
 ## 🔄 CI/CD Pipeline
 
@@ -233,8 +231,8 @@ style K padding:10px
 | Environment | Trigger | URL | Purpose |
 |-------------|---------|-----|---------|
 | **Development** | Local | `localhost:3000` | Local development |
-| **Staging** | Push to `main` | `staging.example.com` | Integration testing |
-| **Production** | Release tag | `example.com` | Live website |
+| **Staging** | Push to `main` | CloudFront URL | Integration testing |
+| **Production** | Release tag | `https://fitzs.io` | Live website |
 
 ## 🔒 Security Features
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -38,29 +38,45 @@ The infrastructure provides:
 
 ## 🚀 Deployment Workflow
 
-### 1. Development
+### Development Environment (CLI-Driven)
+For rapid development and testing:
 ```bash
 cd terraform/environments/dev
 terraform init
 terraform plan
-terraform apply
+terraform apply  # Direct CLI deployment
 ```
 
-### 2. Staging
-```bash
-cd terraform/environments/staging
-terraform init
-terraform plan
-terraform apply
-```
+### Staging & Production (VCS-Driven)
+For staging and production deployments:
 
-### 3. Production
-```bash
-cd terraform/environments/prod
-terraform init
-terraform plan
-terraform apply
-```
+1. **Create Feature Branch**:
+   ```bash
+   git checkout -b feature/infrastructure-changes
+   # Make your terraform changes
+   git add .
+   git commit -m "Update infrastructure"
+   git push origin feature/infrastructure-changes
+   ```
+
+2. **Pull Request Workflow**:
+   - Create PR from feature branch to `main`
+   - **Automatic plan checks** run on both staging AND production
+   - Review plans in PR checks
+   - Address any issues
+
+3. **Deployment**:
+   - **Merge PR to `main`** → **Both staging and production auto-deploy**
+   - Monitor in Terraform Cloud UI
+
+### Environment Summary
+| Environment | Workflow | Trigger | Workspace |
+|-------------|----------|---------|-----------|
+| **Development** | CLI-driven | Manual `terraform apply` | `portfolio-infrastructure-dev` |
+| **Staging** | VCS-driven | Merge to `main` | `portfolio-infrastructure-staging` |
+| **Production** | VCS-driven | Merge to `main` | `portfolio-infrastructure-prod` |
+
+**Note**: Currently both staging and production deploy on merge to `main`. This workflow may change in the future to use release tags for production.
 
 ## 🔧 Module Development
 

--- a/terraform/environments/dev/README.md
+++ b/terraform/environments/dev/README.md
@@ -13,18 +13,18 @@ This environment uses the following modules:
 ### Prerequisites
 1. Terraform Cloud account with `vansteve-portfolio` organization
 2. AWS credentials configured in Terraform Cloud workspace
-3. Terraform CLI installed locally (for development)
+3. Terraform CLI installed locally
 
 ### Terraform Cloud Workspace Setup
 1. Create workspace named: `portfolio-infrastructure-dev`
-2. Connect to this repository
+2. **Connect to this repository** (CLI-driven, not VCS-driven)
 3. Set working directory to: `terraform/environments/dev`
 4. Configure environment variables:
    - `AWS_ACCESS_KEY_ID`
    - `AWS_SECRET_ACCESS_KEY`
    - `AWS_DEFAULT_REGION` (optional)
 
-### Local Development
+### Local Development Workflow
 ```bash
 # Navigate to dev environment
 cd terraform/environments/dev
@@ -35,9 +35,11 @@ terraform init
 # Plan changes
 terraform plan
 
-# Apply changes (via Terraform Cloud)
+# Apply changes directly via CLI
 terraform apply
 ```
+
+**Note**: The dev environment is **CLI-driven** for rapid iteration and testing. Changes are applied directly from your local machine.
 
 ## 🔧 Configuration
 

--- a/terraform/environments/prod/README.md
+++ b/terraform/environments/prod/README.md
@@ -13,52 +13,82 @@ This environment uses the following modules:
 ### Prerequisites
 1. Terraform Cloud account with `vansteve-portfolio` organization
 2. AWS credentials configured in Terraform Cloud workspace
-3. Terraform CLI installed locally (for development)
+3. Repository access for VCS-driven workflow
 
 ### Terraform Cloud Workspace Setup
 1. **Workspace Name**: `portfolio-infrastructure-prod`
-2. Connect to this repository
+2. **Connect to this repository** (VCS-driven)
 3. Set working directory to: `terraform/environments/prod`
 4. Configure environment variables:
    - `AWS_ACCESS_KEY_ID`
    - `AWS_SECRET_ACCESS_KEY`
    - `AWS_DEFAULT_REGION` (optional)
 
-### Local Development
+### VCS-Driven Workflow
+The production environment uses **VCS-driven deployment**:
+
+1. **Development**:
+   ```bash
+   # Create feature branch
+   git checkout -b feature/your-changes
+   
+   # Make infrastructure changes
+   # Edit terraform files as needed
+   
+   # Commit and push
+   git add .
+   git commit -m "Infrastructure changes"
+   git push origin feature/your-changes
+   ```
+
+2. **Pull Request Process**:
+   - Create PR from feature branch to `main`
+   - **Terraform plan runs automatically** on both staging AND production as PR checks
+   - Review plan output in PR checks for both environments
+   - Address any issues and push updates
+
+3. **Deployment**:
+   - **Merge PR to `main`** → **Both staging AND production auto-deploy immediately**
+   - Monitor deployment in Terraform Cloud UI
+   - **Note**: Currently both environments deploy on merge (this may change in future)
+
+### Local Planning (Optional)
 ```bash
-# Navigate to prod environment
+# Navigate to prod environment (for local review only)
 cd terraform/environments/prod
 
-# Initialize Terraform
+# Initialize Terraform (for local development)
 terraform init
 
-# Plan changes
+# Plan changes (local review - does not deploy)
 terraform plan
 
-# Apply changes (via Terraform Cloud)
-terraform apply
+# For domain setup: Set domain_name variable in Terraform Cloud workspace UI
 ```
 
 ## 🔧 Configuration
 
 ### Key Variables
-- `website_bucket_name`: Base name for S3 bucket
-- `domain_name`: Custom domain (configure for production domain)
+- `website_bucket_name`: Base name for S3 bucket (default: `portfolio-prod`)
+- `domain_name`: **Production custom domain** (e.g., `fitzs.io`) - **Required for production**
 - `aws_region`: AWS region for deployment (default: `us-west-2`)
 
 ### Production-Specific Settings
-- **S3 Versioning**: Enabled with production-appropriate retention
-- **CloudFront Logging**: Can be enabled for production monitoring
-- **Price Class**: Configurable based on global requirements
-- **SSL Certificate**: Production domain certificate with DNS validation
+- **S3 Versioning**: Enabled with 90-day retention for production data protection
+- **CloudFront Logging**: Enabled for production monitoring and analytics
+- **Price Class**: `PriceClass_All` for global performance
+- **SSL Certificate**: Automatic via ACM with DNS validation
+- **Route 53**: Hosted zone and DNS records automatically configured
 
 ## 📊 Outputs
 
 After deployment:
-- `website_url`: Complete production website URL
+- `website_url`: Production website URL (https://fitzs.io)
 - `cloudfront_distribution_id`: For cache invalidation
 - `website_bucket_name`: For content uploads
-- `route53_name_servers`: DNS configuration (if using custom domain)
+- `route53_name_servers`: **For domain registrar configuration**
+- `route53_zone_id`: Route 53 hosted zone ID
+- `certificate_arn`: SSL certificate ARN
 
 ## 🔒 Production Considerations
 

--- a/terraform/environments/staging/README.md
+++ b/terraform/environments/staging/README.md
@@ -13,43 +13,67 @@ This environment uses the following modules:
 ### Prerequisites
 1. Terraform Cloud account with `vansteve-portfolio` organization
 2. AWS credentials configured in Terraform Cloud workspace
-3. Terraform CLI installed locally (for development)
+3. Repository access for VCS-driven workflow
 
 ### Terraform Cloud Workspace Setup
-1. Create workspace named: `portfolio-infrastructure-dev`
-2. Connect to this repository
-3. Set working directory to: `terraform/environments/dev`
+1. Create workspace named: `portfolio-infrastructure-staging`
+2. **Connect to this repository** (VCS-driven)
+3. Set working directory to: `terraform/environments/staging`
 4. Configure environment variables:
    - `AWS_ACCESS_KEY_ID`
    - `AWS_SECRET_ACCESS_KEY`
    - `AWS_DEFAULT_REGION` (optional)
 
-### Local Development
-```bash
-# Navigate to dev environment
-cd terraform/environments/dev
+### VCS-Driven Workflow
+The staging environment uses **VCS-driven deployment**:
 
-# Initialize Terraform
+1. **Development**:
+   ```bash
+   # Create feature branch
+   git checkout -b feature/your-changes
+   
+   # Make infrastructure changes
+   # Edit terraform files as needed
+   
+   # Commit and push
+   git add .
+   git commit -m "Infrastructure changes"
+   git push origin feature/your-changes
+   ```
+
+2. **Pull Request Process**:
+   - Create PR from feature branch to `main`
+   - **Terraform plan runs automatically** on staging as PR check
+   - Review plan output in PR checks
+   - Address any issues and push updates
+
+3. **Deployment**:
+   - **Merge PR to `main`** → **Staging auto-deploys immediately**
+   - Monitor deployment in Terraform Cloud UI
+
+### Local Planning (Optional)
+```bash
+# Navigate to staging environment (for local review only)
+cd terraform/environments/staging
+
+# Initialize Terraform (for local development)
 terraform init
 
-# Plan changes
+# Plan changes (local review - does not deploy)
 terraform plan
-
-# Apply changes (via Terraform Cloud)
-terraform apply
 ```
 
 ## 🔧 Configuration
 
 ### Key Variables
-- `website_bucket_name`: Base name for S3 bucket (default: `portfolio-dev`)
+- `website_bucket_name`: Base name for S3 bucket (default: `portfolio-staging`)
 - `domain_name`: Custom domain (leave empty for CloudFront URL only)
 - `aws_region`: AWS region for deployment (default: `us-west-2`)
 
 ### Environment-Specific Settings
-- **S3 Versioning**: Enabled with 7-day retention for non-current versions
-- **CloudFront Logging**: Disabled to reduce costs
-- **Price Class**: `PriceClass_100` (most cost-effective)
+- **S3 Versioning**: Enabled with 30-day retention for non-current versions
+- **CloudFront Logging**: Enabled for testing
+- **Price Class**: `PriceClass_100` (cost-effective for staging)
 - **Tags**: Environment-specific tags for cost tracking
 
 ## 📊 Outputs

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -8,7 +8,7 @@ environment = "prod"
 
 # Website Configuration
 website_bucket_name = "vansteve-portfolio-website"  # Region will be auto-appended: vansteve-portfolio-website-us-west-2
-domain_name = ""  # Leave empty to use CloudFront domain, or set to your custom domain like "fitzs.io"
+domain_name = "fitzs.io"  # Set to your custom domain, or leave empty to use CloudFront domain only
 
 # Project Configuration
 project_name = "portfolio"


### PR DESCRIPTION
Docs (issue #5): Updating documentation for the updated Route53 configuration for domain and dns

Secretly the actual purpose of this PR is that we need a dummy PR that will simply trigger a new deployment, now that we have set the domain_name variable in terraform, but because the terraform workspace is entirely VCS driven, we're making this PR just trigger that deployment. We're just conveiniently updating some readme docs at the same time.

Once this deployment runs, we'll get our route53 nameservers from the terraform output and will use that to update our domain settings, after which we'll wait for DNS propagation