### PR TITLE
Task 1.4 (2): Fix ACM Cert Validation dependency issue

### DIFF
--- a/terraform/modules/cloudfront/main.tf
+++ b/terraform/modules/cloudfront/main.tf
@@ -103,7 +103,7 @@ resource "aws_cloudfront_distribution" "distribution" {
   dynamic "viewer_certificate" {
     for_each = var.domain_name != "" ? [1] : []
     content {
-      acm_certificate_arn      = aws_acm_certificate.cert[0].arn
+      acm_certificate_arn      = aws_acm_certificate_validation.cert[0].certificate_arn
       ssl_support_method       = "sni-only"
       minimum_protocol_version = var.minimum_protocol_version
     }
@@ -124,6 +124,40 @@ resource "aws_acm_certificate" "cert" {
 
   lifecycle {
     create_before_destroy = true
+  }
+}
+
+# Route53 record for ACM certificate validation
+resource "aws_route53_record" "cert_validation" {
+  for_each = var.domain_name != "" ? {
+    for dvo in aws_acm_certificate.cert[0].domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  } : {}
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = var.create_route53_zone ? aws_route53_zone.zone[0].zone_id : var.route53_zone_id
+
+  depends_on = [aws_route53_zone.zone]
+}
+
+# ACM certificate validation
+resource "aws_acm_certificate_validation" "cert" {
+  count                   = var.domain_name != "" ? 1 : 0
+  provider                = aws.us_east_1
+  certificate_arn         = aws_acm_certificate.cert[0].arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+
+  depends_on = [aws_route53_record.cert_validation]
+
+  timeouts {
+    create = "10m"
   }
 }
 


### PR DESCRIPTION
Fix (issue #5): Added ACM cert validation to attempt to fix dependency issue between CF + ACM certificate. We need to wait for the ACM cert to be fully validated before CF tries to use it